### PR TITLE
 Don't display 'you cant do that' unless false is explicitly set

### DIFF
--- a/server.js
+++ b/server.js
@@ -133,7 +133,7 @@ io.on('connection', (socket) => {
               mess: item.text,
             };
             io.in(socket.currentRoom).emit('chatMessage', flavorText);
-          } else if (!item.text && item.successful === 'false') {
+          } else if (!item.text && item.successful === false) {
             const flavorText = {
               type: 'flavor',
               time: message.time,


### PR DESCRIPTION
avoids issue with moving where you successfully move and but it says "you cant do that"